### PR TITLE
Propagate monitor_memory subprocess exit code

### DIFF
--- a/monitor_memory.py
+++ b/monitor_memory.py
@@ -151,3 +151,5 @@ if __name__ == '__main__':
   sys.stderr.write('max rss_memory: {:.2f}GB\n'.format(ptimer.max_rss_memory * 1.07E-9))
   sys.stderr.write('memory check interval: %ss\n' % ptimer.interval)
   sys.stderr.write('return code: %s\n' % ptimer.p.returncode)
+  
+  sys.exit(ptimer.p.returncode)


### PR DESCRIPTION
When profiling memory usage on Midway, sometimes my job will fail but since `monitor_memory.py` swallows the exit code, Slurm will report the job as a success.

This PR modifies the memory monitor to propagate the subprocess's exit code.